### PR TITLE
drop nixpkgs-review flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -15,21 +15,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1651558728,
@@ -46,32 +31,10 @@
         "type": "github"
       }
     },
-    "nixpkgs-review": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1650549072,
-        "narHash": "sha256-3e4xaxDwfgCkMjCSeyGr1vPutos8BzlTi0wUCHhG1+8=",
-        "owner": "Mic92",
-        "repo": "nixpkgs-review",
-        "rev": "d8c01b48b6189287bb7b70c0a67399991f227163",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Mic92",
-        "repo": "nixpkgs-review",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-review": "nixpkgs-review"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,13 @@
 {
-  description = "A very basic flake";
+  description = "Run `nixpkgs-review pr` from Matrix [maintainer=@ckiee]";
 
   inputs = {
     nixpkgs.url =
       "github:nixos/nixpkgs/nixos-unstable"; # We want to use packages from the binary cache
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs-review.url = "github:Mic92/nixpkgs-review";
-    nixpkgs-review.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = inputs@{ self, nixpkgs, flake-utils, nixpkgs-review }:
+  outputs = inputs@{ self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
@@ -20,8 +18,7 @@
           nodejs = node;
           yarn = nyarn;
         };
-        npr = nixpkgs-review.packages.${system}.nixpkgs-review-sandbox;
-        runtimeDeps = [ npr pkgs.git ];
+        runtimeDeps = [ pkgs.nixpkgs-review pkgs.bubblewrap pkgs.git ];
       in rec {
         packages = rec {
           review-bot = y2n.mkYarnPackage {


### PR DESCRIPTION
It's better to use released versions from nixpkgs.
All the sandbox enabled version does is adding bubblewrap to the PATH.
This way the flake also gets more lightweight since it only pulls one
instance of nixpkgs.